### PR TITLE
Automatically include an Accept header in the request parameters when…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This package follows standard semvar, `<major>.<minor>.<build>`. No breaking cha
 * Correctly display the schema title in the schema-tree.
 * Add links to component schema when clicked in bodies of objects.
 * Deprecate `navbar-operations-header` in favor of `navbar-section-header`. Will be removed in a future version.
+* Fix `Accept` header population. Instead of incorrectly using the Response header selector, an Accept Header selector will automatically be shown when it is an option.
 
 ## 2.0
 * `show-server-selection` has now be inverted to be `hide-server-selection` this brings it in line with how html boolean attributes are supposed to work. If you set this value to false previously, now you can hide the section using the new property.

--- a/src/components/api-response.js
+++ b/src/components/api-response.js
@@ -93,7 +93,7 @@ export default class ApiResponse extends LitElement {
       }
       .focused-mode,
       .read-mode {
-        padding-top:24px;
+        padding-top: 3rem;
         margin-top:12px;
         border-top: 1px dashed var(--border-color);
       }`,

--- a/src/components/request-form-table.js
+++ b/src/components/request-form-table.js
@@ -115,7 +115,7 @@ function generatePrimitiveRow(rowData, parentRecursionOptions) {
             <div class="param-constraint">
               ${pattern ? html`<span style="font-weight:bold">Pattern: </span>${pattern}<br/>` : ''}
               ${constraints.length ? html`<span style="font-weight:bold">Constraints: </span>${constraints.join(', ')}<br/>` : ''}
-              ${allowedValues?.split('┃').filter(v => v !== '').map((v, i) => html`
+              ${allowedValues?.filter(v => v !== '').map((v, i) => html`
                 ${i > 0 ? '|' : html`<span style="font-weight:bold">Allowed: </span>`}
                 ${html`
                   <a part="anchor anchor-param-constraint"

--- a/src/components/schema-table.js
+++ b/src/components/schema-table.js
@@ -304,7 +304,7 @@ export default class SchemaTable extends LitElement {
           </span>
           ${constraints.length ? html`<div style='display:inline-block; line-break: anywhere; margin-right:8px;'><span class='bold-text'>Constraints: </span>${constraints.join(', ')}</div><br>` : ''}
           ${defaultValue ? html`<div style='display:inline-block; line-break: anywhere; margin-right:8px'><span class='bold-text'>Default: </span>${defaultValue}</div><br>` : ''}
-          ${allowedValues ? html`<div style='display:inline-block; line-break: anywhere; margin-right:8px'><span class='bold-text'>Allowed: </span>${allowedValues}</div><br>` : ''}
+          ${allowedValues ? html`<div style='display:inline-block; line-break: anywhere; margin-right:8px'><span class='bold-text'>Allowed: </span>${allowedValues.join('┃')}</div><br>` : ''}
           ${pattern ? html`<div style='display:inline-block; line-break: anywhere; margin-right:8px'><span class='bold-text'>Pattern: </span>${pattern}</div><br>` : ''}
           ${example ? html`<div style='display:inline-block; line-break: anywhere; margin-right:8px'><span class='bold-text'>Example: </span>${example}</div><br>` : ''}
         </div>

--- a/src/components/schema-tree.js
+++ b/src/components/schema-tree.js
@@ -297,7 +297,7 @@ export default class SchemaTree extends LitElement {
           ${this.schemaDescriptionExpanded ? html`
             ${constraints.length ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px'><span class='bold-text'>Constraints: </span>${constraints.join(', ')}</div><br>` : ''}
             ${defaultValue ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px'><span class='bold-text'>Default: </span>${defaultValue}</div><br>` : ''}
-            ${allowedValues ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px'><span class='bold-text'>Allowed: </span>${allowedValues}</div><br>` : ''}
+            ${allowedValues ? html`<div style='display:inline-block; line-break:anywhere; margin-right:8px'><span class='bold-text'>Allowed: </span>${allowedValues.join('┃')}</div><br>` : ''}
             ${pattern ? html`<div style='display:inline-block; line-break: anywhere; margin-right:8px'><span class='bold-text'>Pattern: </span>${pattern}</div><br>` : ''}
             ${example ? html`<div style='display:inline-block; line-break: anywhere; margin-right:8px'><span class='bold-text'>Example: </span>${example}</div><br>` : ''}` : ''}
         </div>

--- a/src/styles/api-request-styles.js
+++ b/src/styles/api-request-styles.js
@@ -5,7 +5,7 @@ export default css`
 
 .api-request.focused-mode,
 .api-request.read-mode {
-  padding-top:24px;
+  padding-top: 3rem;
   margin-top:12px;
   border-top: 1px dashed var(--border-color);
 }

--- a/src/templates/endpoint-template.js
+++ b/src/templates/endpoint-template.js
@@ -57,13 +57,6 @@ function endpointHeadTemplate(path) {
 }
 
 function endpointBodyTemplate(path) {
-  const acceptContentTypes = new Set();
-  for (const respStatus in path.responses) {
-    for (const acceptContentType in path.responses[respStatus]?.content) {
-      acceptContentTypes.add(acceptContentType.trim());
-    }
-  }
-  const accept = [...acceptContentTypes].join(', ');
   // Filter API Keys that are non-empty and are applicable to the the path
   const nonEmptyApiKeys = this.resolvedSpec.securitySchemes.filter((v) => (v.finalKeyValue && path.security?.some((ps) => ps[v.apiKeyId]))) || [];
 
@@ -102,7 +95,6 @@ function endpointBodyTemplate(path) {
           fill-defaults = "${!this.hideDefaults}"
           display-nulls="${!!this.includeNulls}"
           enable-console = "${!this.hideExecution}"
-          accept = "${accept}"
           render-style="${this.renderStyle}" 
           schema-style="${this.displaySchemaAsTable ? 'table' : 'tree'}"
           schema-expand-level = "${this.schemaExpandLevel}"

--- a/src/templates/expanded-endpoint-template.js
+++ b/src/templates/expanded-endpoint-template.js
@@ -9,14 +9,6 @@ import '../components/api-response.js';
 
 /* eslint-disable indent */
 export function expandedEndpointBodyTemplate(path, tagName = '') {
-  const acceptContentTypes = new Set();
-  for (const respStatus in path.responses) {
-    for (const acceptContentType in path.responses[respStatus]?.content) {
-      acceptContentTypes.add(acceptContentType.trim());
-    }
-  }
-  const accept = [...acceptContentTypes].join(', ');
-
   // Filter API Keys that are non-empty and are applicable to the the path
   const nonEmptyApiKeys = this.resolvedSpec.securitySchemes.filter((v) => (v.finalKeyValue && path.security && path.security.some((ps) => ps[v.apiKeyId]))) || [];
 
@@ -60,7 +52,6 @@ export function expandedEndpointBodyTemplate(path, tagName = '') {
           fill-defaults = "${!this.hideDefaults}"
           display-nulls="${!!this.includeNulls}"
           enable-console = "${!this.hideExecution}"
-          accept = "${accept}"
           render-style="${this.renderStyle}" 
           schema-style = "${this.displaySchemaAsTable ? 'table' : 'tree'}"
           active-schema-tab = "${this.defaultSchemaTab}"

--- a/src/utils/schema-utils.js
+++ b/src/utils/schema-utils.js
@@ -47,7 +47,7 @@ export function getTypeInfo(parameter, options = { includeNulls: false, enableEx
     title: schema.title || '',
     description: schema.description || '',
     constraints: [],
-    allowedValues: schema.const ?? (Array.isArray(schema.enum) ? schema.enum.join('┃') : ''),
+    allowedValues: typeof schema.const !== 'undefined' && [schema.const] || schema.enum || null,
     arrayType: ''
   };
 
@@ -57,7 +57,7 @@ export function getTypeInfo(parameter, options = { includeNulls: false, enableEx
 
     info.arrayType = `${schema.type} of ${Array.isArray(arrayItemType) ? arrayItemType.join('') : arrayItemType}`;
     info.default = arrayItemDefault;
-    info.allowedValues = schema.const ?? (Array.isArray(schema.items.enum) ? schema.items.enum.join('┃') : '');
+    info.allowedValues = typeof schema.const !== 'undefined' && [schema.const] || schema.items.enum || null;
   }
 
   if (schema.uniqueItems) {


### PR DESCRIPTION
… the content type in the response is configurable. fix #232

![image](https://github.com/Authress-Engineering/openapi-explorer/assets/5056218/3be309bd-275e-4724-be34-e2de96cb5691)
