### PR TITLE
Fix setting token for security schemes other than basic and bearer

### DIFF
--- a/src/openapi-explorer.js
+++ b/src/openapi-explorer.js
@@ -367,8 +367,6 @@ export default class OpenApiExplorer extends LitElement {
       authorizationToken = `Basic ${btoa(authorizationToken)}`;
     } else if (authorizationToken && securityObj.scheme && securityObj.scheme.toLowerCase() === 'bearer') {
       authorizationToken = `Bearer ${authorizationToken}`;
-    } else {
-      authorizationToken = null;
     }
 
     securityObj.clientId = clientId && clientId.trim();
@@ -409,7 +407,7 @@ export default class OpenApiExplorer extends LitElement {
   expandAndGotoOperation(elementId) {
     // Expand full operation and tag
     let isExpandingNeeded = false;
-    
+
     const tag = this.resolvedSpec.tags.find(t => t.paths && t.paths.find(p => p.elementId === elementId));
     const path = tag?.paths?.find((p) => p.elementId === elementId);
     if (path && (!path.expanded || !tag.expanded)) {


### PR DESCRIPTION
The use-case I have for this is combination of session cookie and CSRF protection header.

While the cookie is handled automatically by browser, the token can be set manually in the Authentication section. However it can't be set using `setAuthenticationConfiguration` method, because the conditions only allow certain schemes to be configured.

![image](https://github.com/Authress-Engineering/openapi-explorer/assets/5196749/c09ef3f3-4d7d-48fa-823f-e9471edfa637)

Rather than preventing valid cases, the method should allow configuring any security scheme, even if it doesn't necessarily make sense.