### PR TITLE
Schema representation improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ This package follows standard semvar, `<major>.<minor>.<build>`. No breaking cha
 * Prevent making requests when required path parameters are not specified.
 * Automatically retry fetching the spec if it doesn't work for any reason.
 * Fix array description display preference to be first--The Array description, and then only second--The array item schema description, so that the "more specific" description wins, even though the "items" description is more deeply nested. This aligns to the expected behavior of preference in the json schema.
+* Treat `allOf` the same way as `oneOf` and `anyOf` instead of trying to merge them as a single object,
+  despite the not even necessarily being objects.
+* Added an `schema-compact-single-x-of-option` option to display `oneOf`, `allOf` and `anyOf` in more compact
+  way when they contain only one item.
+* `oneOf`, `allOf` and `anyOf` items now contain a link to schema component if referenced.
+* More consistent display of links to components with long schema names.
+* Added `advanced-search-dialog` part so it can by styled separately.
+* Type is now displayed together with format in parentheses instead of displaying format directly.
+* Fixed sample value for `byte` that was crashing on undefined `Buffer`.
 
 ## 2.1
 * Add `x-locale` vendor extension to specify the locale of the spec.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -7,12 +7,14 @@
 * `spec-url` - OpenAPI specification document url
 * `server-url` - Set the server url, when not specified defaults to the first listed server in the spec.
 
-#### Disable configuration
+#### Schema configuration
 * `display-nulls` - [false] Force rendering of null types in the models. By default the models will assume `null` is equivalent to `not-required`.
 * `hide-defaults` - [false] Prevents filling the request data with the default data.
 * `collapse` - [false] Set the operations and components collapsed by default
 * `tree` - [false] Converts the body displays from schema tables to object jsons.
 * `schema-expand-level` - [9999] Expands the display of schemas and models to this depth. Set to `1` to display only the first level properties.
+* `schema-compact-single-x-of-option` - [false] Display item immediately without enumeration when `allOf`, `oneOf`
+  or `anyOf` contains only one item.
 
 ### Hide/Show Sections
 * `hide-console` - Disable executing the API from the specification. Removes the `execute button` when disabled.

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -71,3 +71,4 @@ Buttons             | `btn` `btn-fill` `btn-outline` `btn-search`
 Checkboxes/ Toggles | `checkbox` `checkbox-auth-scope`
 Anchors             | `anchor` `anchor-overview`
 Schema Table/Tree   | `schema-key` `schema-type` `schema-description` `schema-table-header`
+Search dialog       | `advanced-search-dialog`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-explorer",
-  "version": "2.2.711",
+  "version": "0.0.0",
   "description": "OpenAPI Explorer - API viewer with dynamically generated components, documentation, and interaction console",
   "author": "Authress Developers <developers@authress.io>",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-explorer",
-  "version": "2.2.710",
+  "version": "2.2.711",
   "description": "OpenAPI Explorer - API viewer with dynamically generated components, documentation, and interaction console",
   "author": "Authress Developers <developers@authress.io>",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-explorer",
-  "version": "0.0.0",
+  "version": "2.2.710",
   "description": "OpenAPI Explorer - API viewer with dynamically generated components, documentation, and interaction console",
   "author": "Authress Developers <developers@authress.io>",
   "type": "module",

--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -513,6 +513,7 @@ export default class ApiRequest extends LitElement {
             style = 'display: ${this.selectedRequestBodyType === reqBody.mimeType ? 'block' : 'none'};'
             .data = '${schemaAsObj}'
             schema-expand-level = "${this.schemaExpandLevel}"
+            schema-compact-single-x-of-option = ${this.schemaCompactSingleXxxOfOption}
             schema-hide-read-only = "${this.schemaHideReadOnly.includes(this.method)}"
             schema-hide-write-only = false
             exportparts="schema-key, schema-type, schema-description, schema-table-header"
@@ -526,6 +527,7 @@ export default class ApiRequest extends LitElement {
             style = 'display: ${this.selectedRequestBodyType === reqBody.mimeType ? 'block' : 'none'};'
             .data = '${schemaAsObj}'
             schema-expand-level = "${this.schemaExpandLevel}"
+            schema-compact-single-x-of-option = ${this.schemaCompactSingleXxxOfOption}
             schema-hide-read-only = "${this.schemaHideReadOnly.includes(this.method)}"
             schema-hide-write-only = false
             exportparts="schema-key, schema-type, schema-description"

--- a/src/components/api-response.js
+++ b/src/components/api-response.js
@@ -308,6 +308,7 @@ export default class ApiResponse extends LitElement {
             .data = '${mimeRespDetails.schemaTree}'
             class = 'example-panel ${this.renderStyle === 'read' ? 'border pad-8-16' : 'border-top pad-top-8'}'
             schema-expand-level = "${this.schemaExpandLevel}"
+            schema-compact-single-x-of-option = ${this.schemaCompactSingleXxxOfOption}
             schema-hide-read-only = false
             schema-hide-write-only = ${this.schemaHideWriteOnly}
             exportparts="schema-key, schema-type, schema-description, schema-table-header"
@@ -318,6 +319,7 @@ export default class ApiResponse extends LitElement {
             .data = '${mimeRespDetails.schemaTree}'
             class = 'example-panel ${this.renderStyle === 'read' ? 'border pad-8-16' : 'pad-top-8'}'
             schema-expand-level = "${this.schemaExpandLevel}"
+            schema-compact-single-x-of-option = ${this.schemaCompactSingleXxxOfOption}
             schema-hide-read-only = false
             schema-hide-write-only = ${this.schemaHideWriteOnly}
             exportparts="schema-key, schema-type, schema-description"

--- a/src/components/request-form-table.js
+++ b/src/components/request-form-table.js
@@ -18,7 +18,7 @@ function generateFormRows(data, options, dataType = 'object', key = '', descript
   let rawKeyLabel = '';
   let keyDescr = '';
   let isOneOfLabel = false;
-  if (key.startsWith('::ONE~OF') || key.startsWith('::ANY~OF')) {
+  if (key.startsWith('::ONE~OF') || key.startsWith('::ANY~OF') || key.startsWith('::ALL~OF')) {
     rawKeyLabel = key.replace('::', '').replace('~', ' ');
     isOneOfLabel = true;
   } else if (key.startsWith('::OPTION')) {

--- a/src/components/schema-table.js
+++ b/src/components/schema-table.js
@@ -165,7 +165,7 @@ export default class SchemaTable extends LitElement {
     let keyLabel = '';
     let keyDescr = '';
     let isOneOfLabel = false;
-    if (key.startsWith('::ONE~OF') || key.startsWith('::ANY~OF')) {
+    if (key.startsWith('::ONE~OF') || key.startsWith('::ANY~OF') || key.startsWith('::ALL~OF')) {
       keyLabel = key.replace('::', '').replace('~', ' ');
       isOneOfLabel = true;
     } else if (key.startsWith('::OPTION')) {
@@ -284,23 +284,35 @@ export default class SchemaTable extends LitElement {
       return { result: undefined, keyLabelMaxCharacterLength: newIndentLevel };
     }
     
+
+    const titleString = schemaTitle || title;
+    const descriptionString = schemaDescription || description;
+    const typeWithFormat = format ? `${type} (${format})` : type;
+
+    const renderKeyDescription = (title) => {
+      return title ? html`<span class="xxx-of-descr schema-link" style="color:var(--secondary-color)" @click="${() => this.scrollToSchemaComponentByName(title)}">${title}</span>` : '';
+    };
+
     const result = html`
       <div class = "tr">
         <div class="td key ${deprecated ? 'deprecated' : ''}" part="schema-key" style='padding-left:${leftPadding}px'>
           ${keyLabel?.endsWith('*')
             ? html`<span class="key-label requiredStar" title="Required">${keyLabel.substring(0, keyLabel.length - 1)}</span>`
             : key.startsWith('::OPTION')
-              ? html`<span class='xxx-of-key'>${keyLabel}</span><span class="xxx-of-descr">${keyDescr}</span>`
-              : html`${keyLabel ? html`<span class="key-label"> ${keyLabel}</span>` : html`<span class="xxx-of-descr">${schemaTitle}</span>`}`
+              ? html`<span class='xxx-of-key'>${keyLabel}</span>${renderKeyDescription(keyDescr)}`
+              : html`${keyLabel
+                  ? html`<span class="key-label"> ${keyLabel}</span>`
+                  : renderKeyDescription(schemaTitle)
+                }`
           }
         </div>
         <div class='td key-type' part="schema-type">
-          <div>${dataType === 'array' ? '[' : ''}<span class="${cssType}">${format || type}</span>${dataType === 'array' ? ']' : ''}</div>
+          <div>${dataType === 'array' ? '[' : ''}<span class="${cssType}">${typeWithFormat}</span>${dataType === 'array' ? ']' : ''}</div>
           <div class="attributes ${cssType}" style="font-family: var(--font-mono);" title="${readOrWriteOnly === '🆁' && 'Read only attribute' || readOrWriteOnly === '🆆' && 'Write only attribute' || ''}">${readOrWriteOnly}</div>
         </div>
         <div class='td key-descr' part="schema-description">
           <span class="m-markdown-small" style="vertical-align: middle;">
-            ${unsafeHTML(toMarkdown(`${`${(schemaTitle || title) ? `**${schemaTitle || title}${schemaDescription || description ? ':' : ''}**` : ''} ${schemaDescription || description}` || ''}`))}
+            ${unsafeHTML(toMarkdown(`${`${titleString ? `**${titleString}${descriptionString ? ':' : ''}**` : ''} ${descriptionString}` || ''}`))}
           </span>
           ${constraints.length ? html`<div style='display:inline-block; line-break: anywhere; margin-right:8px;'><span class='bold-text'>Constraints: </span>${constraints.join(', ')}</div><br>` : ''}
           ${defaultValue !== '' ? html`<div style='display:inline-block; line-break: anywhere; margin-right:8px'><span class='bold-text'>Default: </span>${defaultValue}</div><br>` : ''}
@@ -310,7 +322,7 @@ export default class SchemaTable extends LitElement {
         </div>
       </div>
     `;
-    return { result, keyLabelMaxCharacterLength: keyLabel.length + newIndentLevel, typeMaxCharacterLength: (format || type).length };
+    return { result, keyLabelMaxCharacterLength: keyLabel.length + newIndentLevel, typeMaxCharacterLength: typeWithFormat.length };
   }
   /* eslint-enable indent */
 

--- a/src/components/schema-table.js
+++ b/src/components/schema-table.js
@@ -276,8 +276,10 @@ export default class SchemaTable extends LitElement {
                 </div>
                 <div class='td key-type' part="schema-type">
                   ${displaySchemaLink
-                    ? html`<div class="schema-link" style="overflow: hidden; text-overflow: ellipsis" @click='${() => this.scrollToSchemaComponentByName(displaySchemaLink)}'>
-                      ${dataType === 'array' ? '[' : ''}<span style="color: var(--secondary-color); white-space: nowrap" >${detailObjType}</span>${dataType === 'array' ? ']' : ''}
+                    ? html`<div class="ellipsis" @click='${() => this.scrollToSchemaComponentByName(displaySchemaLink)}'>
+                        <span class="schema-link nowrap bg inline-border">
+                          ${dataType === 'array' ? '[' : ''}<span class="secondary" >${detailObjType}</span>${dataType === 'array' ? ']' : ''}
+                        </span>
                     </div>`
                     : html`<div>${(data['::type'] || '').includes('xxx-of') ? '' : `${dataType === 'array' ? '[' : ''}${detailObjType}${dataType === 'array' ? ']' : ''}`}</div>`
                   }

--- a/src/components/schema-tree.js
+++ b/src/components/schema-tree.js
@@ -141,6 +141,10 @@ export default class SchemaTree extends LitElement {
     this.requestUpdate();
   }
 
+  scrollToSchemaComponentByName(componentName) {
+    this.dispatchEvent(new CustomEvent('scrollToSchemaComponentByName', { bubbles: true, composed: true, detail: componentName }));
+  }
+
   generateTree(data, dataType = 'object', arrayType = '', flags = {}, key = '', title = '', description = '', schemaLevel = 0, indentLevel = 0) {
     if (!data) {
       return html`<div class="null" style="display:inline;">
@@ -156,7 +160,7 @@ export default class SchemaTree extends LitElement {
     }
     let keyLabel = '';
     let keyDescr = '';
-    if (key.startsWith('::ONE~OF') || key.startsWith('::ANY~OF')) {
+    if (key.startsWith('::ONE~OF') || key.startsWith('::ANY~OF') || key.startsWith('::ALL~OF')) {
       keyLabel = key.replace('::', '').replace('~', ' ');
     } else if (key.startsWith('::OPTION')) {
       const parts = key.split('~');
@@ -278,18 +282,24 @@ export default class SchemaTree extends LitElement {
 
     const titleString = schemaTitle || title;
     const descriptionString = schemaDescription || description;
+    const typeWithFormat = format ? `${type} (${format})` : type;
+
+    const renderKeyDescription = (title) => {
+      return title ? html`<span class="xxx-of-descr schema-link" style="color:var(--secondary-color)" @click="${() => this.scrollToSchemaComponentByName(title)}">${title}</span>` : '';
+    };
+
     return html`
       <div class="tr">
         <div class="td key ${deprecated ? 'deprecated' : ''}" style='min-width:${minFieldColWidth}px'>
           ${keyLabel.endsWith('*')
             ? html`<span class="key-label requiredStar" title="Required">${keyLabel.substring(0, keyLabel.length - 1)}</span>:`
             : key.startsWith('::OPTION')
-              ? html`<span class='key-label xxx-of-key'>${keyLabel}</span><span class="xxx-of-descr">${keyDescr}</span>`
+              ? html`<span class='key-label xxx-of-key'>${keyLabel}</span>${renderKeyDescription(keyDescr)}`
               : schemaLevel > 0
                 ? html`<span class="key-label">${keyLabel}:</span>`
                 : ''
           }
-          <span>${dataType === 'array' ? '[' : ''}<span class="${cssType}">${format || type}</span>${dataType === 'array' ? ']' : ''}</span>
+          <span>${dataType === 'array' ? '[' : ''}<span class="${cssType}">${typeWithFormat}</span>${dataType === 'array' ? ']' : ''}</span>
 
         </div>
         <div class="td key-descr">

--- a/src/openapi-explorer.js
+++ b/src/openapi-explorer.js
@@ -78,6 +78,12 @@ export default class OpenApiExplorer extends LitElement {
         }
       },
       schemaExpandLevel: { type: Number, attribute: 'schema-expand-level' },
+      schemaCompactSingleXxxOfOption: {
+        type: Boolean, attribute: 'schema-compact-single-x-of-option',
+        converter(value) {
+          return value !== 'false' && value !== false;
+        }
+      },
 
       // API Server
       serverUrl: { type: String, attribute: 'server-url' },
@@ -209,6 +215,7 @@ export default class OpenApiExplorer extends LitElement {
 
     if (!this.defaultSchemaTab || !'body, model, form,'.includes(`${this.defaultSchemaTab},`)) { this.defaultSchemaTab = 'model'; }
     if (!this.schemaExpandLevel || this.schemaExpandLevel < 1) { this.schemaExpandLevel = 99999; }
+    if (typeof this.schemaCompactSingleXxxOfOption === 'undefined') { this.schemaCompactSingleXxxOfOption = false; }
     this.schemaHideReadOnly = ['post', 'put', 'patch', 'query'].join(',');
     this.schemaHideWriteOnly = true;
     if (!this.responseAreaHeight) {

--- a/src/styles/schema-styles.js
+++ b/src/styles/schema-styles.js
@@ -107,6 +107,33 @@ export default css`
   }
 }
 
+.bg {
+  background-color: var(--bg);
+}
+
+.secondary {
+  color: var(--secondary-color);
+}
+
+.nowrap {
+  white-space: nowrap;
+}
+
+.ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ellipsis:hover {
+  overflow: visible;
+  z-index: 100;
+}
+
+.inline-border {
+  padding: 0.2rem;
+  margin: -0.2rem;
+}
+
 .expanded-endpoint-component > h2:hover, .schema-link:hover {
   cursor: pointer;
   text-decoration: underline;

--- a/src/templates/advance-search-template.js
+++ b/src/templates/advance-search-template.js
@@ -19,7 +19,7 @@ export default function searchByPropertiesModalTemplate() {
   return html`
   ${this.showAdvancedSearchDialog
     ? html`
-      <div class="dialog-box-overlay">
+      <div class="dialog-box-overlay" part="advanced-search-dialog">
         <div class="dialog-box">
           <header class="dialog-box-header">
             <span class="dialog-box-title">Advanced Search</span>
@@ -54,20 +54,20 @@ export default function searchByPropertiesModalTemplate() {
                 </div>
               </div>
             </span>
-            
+
             <div class="advanced-search-results">
               ${this.advancedSearchMatches && this.advancedSearchMatches.map((path) => html`
                 <div
                   class="mono-font small-font-size hover-bg" tabindex = '0'
-                  style='padding: 5px; cursor: pointer; border-bottom: 1px solid var(--light-border-color); ${path.deprecated ? 'filter:opacity(0.5);' : ''}' 
+                  style='padding: 5px; cursor: pointer; border-bottom: 1px solid var(--light-border-color); ${path.deprecated ? 'filter:opacity(0.5);' : ''}'
                   data-content-id='${path.elementId}'
                   @click="${(e) => {
                     this.matchPaths = ''; // clear quick filter if applied
                     closeAdvancedSearchDialog(); // Hide Search Dialog
                     this.requestUpdate();
                     this.scrollToEventTarget(e, true);
-                  }}"> 
-                  <span class="upper bold-text method-fg ${path.method}">${path.method}</span> 
+                  }}">
+                  <span class="upper bold-text method-fg ${path.method}">${path.method}</span>
                   <span>${path.path}</span> - <span class="regular-font gray-text">${path.summary}</span>
                 </div>
               `)}

--- a/src/templates/components-template.js
+++ b/src/templates/components-template.js
@@ -18,13 +18,16 @@ function componentBodyTemplate(sComponent) {
       .data = '${formdataPartSchema}'
       @scrollToSchemaComponentByName=${v => this.scrollToSchemaComponentByName(v)}
       schema-expand-level = "${this.schemaExpandLevel}"
+      schema-compact-single-x-of-option = ${this.schemaCompactSingleXxxOfOption}
       schema-hide-read-only=false
       schema-hide-write-only=false
       exportparts="schema-key, schema-type, schema-description, schema-table-header"> </schema-table>`
-        
+
     : html`<schema-tree
         .data = '${formdataPartSchema}'
+        @scrollToSchemaComponentByName=${v => this.scrollToSchemaComponentByName(v)}
         schema-expand-level = "${this.schemaExpandLevel}"
+        schema-compact-single-x-of-option = ${this.schemaCompactSingleXxxOfOption}
         schema-hide-read-only=false
         schema-hide-write-only=false
         exportparts="schema-key, schema-type, schema-description"> </schema-tree>`

--- a/src/utils/schema-utils.js
+++ b/src/utils/schema-utils.js
@@ -180,7 +180,7 @@ export function getSampleValueByType(schemaObj, fallbackPropertyName, skipExampl
           return '4e0ba220-9575-11eb-a8b3-0242ac130003';
         case 'byte':
           // Byte type is actually a base64 encoded string: https://spec.openapis.org/oas/v3.0.0#data-types
-          return Buffer.from('example').toString('base64');
+          return btoa('example');
         default:
           return schemaObj.format;
       }
@@ -346,7 +346,7 @@ export function schemaInObjectNotation(rawSchema, options, level = 0, suffix = '
     const obj = schemaInObjectNotation(schema, options, 0);
     const resultObj = typeof obj === 'object' && !Array.isArray(obj) ? obj : {};
     if (Object.keys(objWithAnyOfProps).length) {
-      let label = (anyOf && `::ANY~OF ${suffix}`)
+      const label = (anyOf && `::ANY~OF ${suffix}`)
         || (oneOf && `::ONE~OF ${suffix}`)
         || (allOf && `::ALL~OF ${suffix}`);
       resultObj[label] = objWithAnyOfProps;


### PR DESCRIPTION
I made some changes to the way schemas are visualized to better fit my use cases, but I think they're more general use cases and are in-line with what OpenAPI is describing.

![image](https://github.com/Authress-Engineering/openapi-explorer/assets/5196749/077ba078-bb71-4218-b92b-826ca3eae9ee)

I also added new `schema-compact-single-x-of-option` option for more compact display of single item `xxxOf`. It would be better to move the schema link to the type column, but internal representation is a too messy for that and I can't spend that much extra time on it, as that would require substantial rewrite.

![image](https://github.com/Authress-Engineering/openapi-explorer/assets/5196749/3dd91670-e77a-4bd6-a998-ea963262f9fb)

Additional details can be found in the documentation and changelog.