### PR TITLE
navigate to complete url instead of only fragment/hash

### DIFF
--- a/src/utils/common-utils.js
+++ b/src/utils/common-utils.js
@@ -149,7 +149,10 @@ export function replaceState(rawElementId) {
   const query = new URLSearchParams(currentQuery);
   query.delete('route');
   const newQuery = query.toString().length > 1 ? `${query.toString()}&route=${elementId}` : `route=${elementId}`;
-  window.history.pushState(null, null, `#${currentNavigationHashPart}?${newQuery}`);
+
+  const fragment = `#${currentNavigationHashPart}?${newQuery}`;
+  const url = new URL(fragment, window.location.href);
+  window.history.pushState(null, null, url.href);
 }
 
 export function toMarkdown(markdownStringRaw) {


### PR DESCRIPTION
Using only fragment works completely fine unless [base tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/base) is added in head (which makes also pushState urls be relative to it instead of to the current url). Fix by constructing complete url relative to current location.