### PR TITLE
don't push state with same url

### DIFF
--- a/src/utils/common-utils.js
+++ b/src/utils/common-utils.js
@@ -151,8 +151,11 @@ export function replaceState(rawElementId) {
   const newQuery = query.toString().length > 1 ? `${query.toString()}&route=${elementId}` : `route=${elementId}`;
 
   const fragment = `#${currentNavigationHashPart}?${newQuery}`;
-  const url = new URL(fragment, window.location.href);
-  window.history.pushState(null, null, url.href);
+  const currentHref = window.location.href;
+  const url = new URL(fragment, currentHref);
+  if (url.href !== currentHref) {
+    window.history.pushState(null, null, url.href);
+  }
 }
 
 export function toMarkdown(markdownStringRaw) {


### PR DESCRIPTION
Currently navigating through documentation sometimes leads to duplicate history entries, also when navigating back to documentation page either from another documentation page or from different site, pushState not only add additional entry, but also removes all history in front.

Ensuring that pushState is done only if new url is not equal current resolves this. I see only one quirky downside - it is not possible to create multiple history entries by navigating to same documentation page.

Steps to reproduce:

1. Goto https://github.com/Authress-Engineering/openapi-explorer
1. Navigate to the demo using link `OpenAPI Explorer Demo`
1. Check history
   * Expected last history entry to be the github page
   * Instead there are 2 entries of demo page after the github page
1. Navigate back 3 times (until github page)
1. Navigate forward
   * Same expecation about last history entry to be the github page and instead having 2 entries of demo page
1. Click `Authentication` link in the menu
1. Navigate back
1. Try to navigate forward
   * Expected to have a history entry in front with `Authentication` page
   * Instead no history entry, so not possible to navigate forward to it
1. Navigate outside of documentation either by clicking `Sign up for Authress` at the bottom or typing a new url (e.g. example.com)
1. Navigate back
1. Try to navigate forward
   * Expected to have a history entry in front (https://authress.io, https://example.com, or some other url that was typed)
   * Instead no history entry, so not possible to navigate forward to it

Thank you @cbliard for discovering it https://github.com/opf/openproject/pull/21484#pullrequestreview-3597442766