### PR TITLE
Add configurable load-timeout to show error instead of endless spinner

### DIFF
--- a/src/openapi-explorer.js
+++ b/src/openapi-explorer.js
@@ -155,7 +155,8 @@ export default class OpenApiExplorer extends LitElement {
       // Internal Properties
       loading: { type: Boolean }, // indicates spec is being loaded
       showAdvancedSearchDialog: { type: Boolean },
-      advancedSearchMatches: { type: Object }
+      advancedSearchMatches: { type: Object },
+      loadTimeout: { type: Number, attribute: 'load-timeout' }
     };
   }
 
@@ -218,6 +219,7 @@ export default class OpenApiExplorer extends LitElement {
     if (!this.fetchCredentials || !'omit, same-origin, include,'.includes(`${this.fetchCredentials},`)) { this.fetchCredentials = ''; }
 
     if (!this.showAdvancedSearchDialog) { this.showAdvancedSearchDialog = false; }
+    if (!this.loadTimeout) { this.loadTimeout = 5000; }
 
     window.addEventListener('hashchange', () => {
       this.scrollTo(getCurrentElement());
@@ -328,7 +330,13 @@ export default class OpenApiExplorer extends LitElement {
       this.resolvedSpec = null;
       this.loading = true;
       this.loadingFailedError = null;
-      const spec = await ProcessSpec(specUrlOrObject, this.serverUrl);
+      const specPromise = ProcessSpec(specUrlOrObject, this.serverUrl);
+      const timeoutPromise = new Promise((_, reject) =>
+        setTimeout(() => reject(new Error(
+          `Loading the spec timed out after ${this.loadTimeout / 1000} seconds`
+        )), this.loadTimeout)
+      );
+      const spec = await Promise.race([specPromise, timeoutPromise]);
       this.loading = false;
       if (spec === undefined || spec === null) {
         console.error('Unable to resolve the API spec. '); // eslint-disable-line no-console

--- a/tests/load-timeout.test.js
+++ b/tests/load-timeout.test.js
@@ -1,0 +1,64 @@
+import test from 'ava';
+
+/**
+ * Tests for the load-timeout feature.
+ *
+ * The core fix is a Promise.race between ProcessSpec and a timeout.
+ * We test the pattern directly here since the component requires a browser environment.
+ */
+
+test('Promise.race rejects with timeout when inner promise hangs', async (t) => {
+  const neverResolves = new Promise(() => {});
+  const loadTimeout = 200;
+
+  const timeoutPromise = new Promise((_, reject) =>
+    setTimeout(() => reject(new Error(
+      `Loading the spec timed out after ${loadTimeout / 1000} seconds`
+    )), loadTimeout)
+  );
+
+  const error = await t.throwsAsync(() => Promise.race([neverResolves, timeoutPromise]));
+  t.is(error.message, 'Loading the spec timed out after 0.2 seconds');
+});
+
+test('Promise.race resolves normally when inner promise is faster than timeout', async (t) => {
+  const fastPromise = new Promise((resolve) => setTimeout(() => resolve('spec-data'), 50));
+  const loadTimeout = 2000;
+
+  const timeoutPromise = new Promise((_, reject) =>
+    setTimeout(() => reject(new Error(
+      `Loading the spec timed out after ${loadTimeout / 1000} seconds`
+    )), loadTimeout)
+  );
+
+  const result = await Promise.race([fastPromise, timeoutPromise]);
+  t.is(result, 'spec-data');
+});
+
+test('Promise.race rejects with inner error when it rejects before timeout', async (t) => {
+  const failingPromise = new Promise((_, reject) =>
+    setTimeout(() => reject(new Error('Network error')), 50)
+  );
+  const loadTimeout = 2000;
+
+  const timeoutPromise = new Promise((_, reject) =>
+    setTimeout(() => reject(new Error(
+      `Loading the spec timed out after ${loadTimeout / 1000} seconds`
+    )), loadTimeout)
+  );
+
+  const error = await t.throwsAsync(() => Promise.race([failingPromise, timeoutPromise]));
+  t.is(error.message, 'Network error');
+});
+
+test('timeout message formats correctly for default 5000ms', (t) => {
+  const loadTimeout = 5000;
+  const message = `Loading the spec timed out after ${loadTimeout / 1000} seconds`;
+  t.is(message, 'Loading the spec timed out after 5 seconds');
+});
+
+test('timeout message formats correctly for custom 2000ms', (t) => {
+  const loadTimeout = 2000;
+  const message = `Loading the spec timed out after ${loadTimeout / 1000} seconds`;
+  t.is(message, 'Loading the spec timed out after 2 seconds');
+});


### PR DESCRIPTION
When loading a spec from a slow/unreachable URL, ProcessSpec can hang forever because openapi-resolver's abort handler swallows the fetch rejection. Wrap ProcessSpec in Promise.race with a configurable timeout so the existing error display path is triggered.

This PR adds a `load-timeout` attribute (default: 5000ms) that controls how long to wait before showing a timeout error. Usage:

```html
  <openapi-explorer spec-url="..." load-timeout="10000"></openapi-explorer>
```