### PR TITLE
Add toposort as a runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "openapi-resolver": "^4.1.71",
     "prismjs": "^1.29.0",
     "randexp": "^0.5.3",
+    "toposort": "^2.0.2",
     "xml-but-prettier": "^1.0.1"
   },
   "scripts": {
@@ -117,7 +118,6 @@
     "sinon-chai": "^3.3.0",
     "style-loader": "^2.0.0",
     "terser-webpack-plugin": "^5.1.1",
-    "toposort": "^2.0.2",
     "webpack": "^5.103.0",
     "webpack-bundle-analyzer": "^5.0.1",
     "webpack-cli": "^6.0.1",


### PR DESCRIPTION
Fixes https://github.com/Authress-Engineering/openapi-explorer/issues/298