### PR TITLE
Correct lost/incorrect focus after interactions

### DIFF
--- a/src/openapi-explorer.js
+++ b/src/openapi-explorer.js
@@ -423,6 +423,7 @@ export default class OpenApiExplorer extends LitElement {
       const gotoEl = this.shadowRoot.getElementById(tmpElementId);
       if (gotoEl) {
         gotoEl.scrollIntoView({ behavior: 'auto', block: 'start' });
+        gotoEl.focus();
         replaceState(tmpElementId);
       }
     }, isExpandingNeeded ? 150 : 0);
@@ -459,6 +460,7 @@ export default class OpenApiExplorer extends LitElement {
         const gotoEl = this.shadowRoot.getElementById(anchor.replace('#', ''));
         if (gotoEl) {
           gotoEl.scrollIntoView({ behavior: 'auto', block: 'start' });
+          gotoEl.focus();
         }
       }
     }
@@ -603,19 +605,21 @@ export default class OpenApiExplorer extends LitElement {
         component.expanded = true;
       }
       contentEl.scrollIntoView({ behavior: 'auto', block: 'start' });
+      contentEl.focus();
 
       // Update Location Hash
       replaceState(elementId);
       newNavEl = this.shadowRoot.getElementById(`link-${elementId}`);
     } else if (elementId.match('cmp--') || elementId.match('tag--') || elementId.match('overview--') || elementId.match('auth--') || elementId.match('servers--')) {
       contentEl.scrollIntoView({ behavior: 'auto', block: 'start' });
+      contentEl.focus();
 
       // Update Location Hash
       replaceState(elementId);
       newNavEl = this.shadowRoot.getElementById(`link-${elementId}`);
     } else {
       this.shadowRoot.getElementById('operations-root').scrollIntoView({ behavior: 'auto', block: 'start' });
-
+      this.shadowRoot.getElementById('operations-root').focus();
       // Update Location Hash
       replaceState(elementId);
       newNavEl = this.shadowRoot.getElementById(`link-${elementId}`);
@@ -642,6 +646,7 @@ export default class OpenApiExplorer extends LitElement {
       if (waitForComponentToExpand) {
         setTimeout(() => newNavEl.scrollIntoView({ behavior: 'auto', block: 'center' }), 600);
       }
+      newNavEl.focus();
     }
 
     await sleep(0);

--- a/src/utils/common-utils.js
+++ b/src/utils/common-utils.js
@@ -47,6 +47,7 @@ export function copyToClipboard(copyData, eventTarget) {
       setTimeout(() => {
         btnEl.innerText = getI18nText('operations.copy');
       }, 5000);
+      btnEl.focus();
     }
   } catch (err) {
     console.error('Unable to copy', err); // eslint-disable-line no-console

--- a/src/utils/common-utils.js
+++ b/src/utils/common-utils.js
@@ -47,7 +47,6 @@ export function copyToClipboard(copyData, eventTarget) {
       setTimeout(() => {
         btnEl.innerText = getI18nText('operations.copy');
       }, 5000);
-      btnEl.focus();
     }
   } catch (err) {
     console.error('Unable to copy', err); // eslint-disable-line no-console


### PR DESCRIPTION
Currently, in keyboard navigation and generally, when the copy button is clicked, focus is lost (it goes to an element that is added and then immediately removed from the page). The expectation is for focus to remain on this button.

Also currently, navigation links in the side nav load new content and scroll to that content without a new page load. However, focus remains on the link that triggered the content to appear, instead of moving to the new content. The expectation for keyboard navigation/screen readers is that the focus will move to the top of the new content (the same element that is scrolled into view).

This PR corrects both issues by setting focus on the correct elements in these cases.